### PR TITLE
fix possible read from unitial value in transport mode

### DIFF
--- a/dsc.c
+++ b/dsc.c
@@ -1244,7 +1244,7 @@ void safe_exit()
 	server_release(&MAIN_CONFIG);
 	if ( 0 == pthread_cancel( manipulate_tid) )
 	{
-		void *res;
+		void *res = NULL;
 		pthread_join( manipulate_tid, &res );
 		if ( res == PTHREAD_CANCELED )
 			printf( "close manipulate thread\n");

--- a/include/libqueue/queue.h
+++ b/include/libqueue/queue.h
@@ -14,8 +14,8 @@ struct qelement
 { 
 	struct qelement * next;
 	struct qelement * prev;
-	void            * data;
 	size_t            data_size;
+	void            * data;
 };
 
 typedef struct qelement qelement_t;

--- a/src/libqueue/push.c
+++ b/src/libqueue/push.c
@@ -40,5 +40,8 @@ void * push_queue(queue_t * queues, int qnum, void * data, size_t size)
 	
  	pthread_mutex_unlock(&queue->mutex);
 	
-	return temp->data;
+	if (queue->mode == Q_STANDART_MODE)
+		return temp->data;
+	
+	return NULL;
 }


### PR DESCRIPTION
Возможно было затирание памяти в транспортном режиме, т.к возврат значения идет за границей блокировок. Это вызывало обращение к освобожденной памяти.
